### PR TITLE
STM32MP2-14: Initial support for stm32mp257f-dk board (discovery kit).

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -57,3 +57,9 @@ TEZI_ROOT_SUFFIX:stm32mp2common = "ota-ext4"
 # userfs images are disabled in the TorizonOS distro, so it is ok to change the common suffix.
 PARTITIONS_SUFFIX = "ota-ext4"
 PARTITIONS_IMAGES[rootfs] = "${STM32MP_ROOTFS_IMAGE},${STM32MP_ROOTFS_LABEL},,${STM32MP_ROOTFS_SIZE},System"
+
+# Enable built eMMC images for the Disco target
+BOOTDEVICE_LABELS:append:stm32mp25-disco = " emmc"
+STM32MP_DT_FILES_EMMC:stm32mp25-disco    += "stm32mp257f-dk"
+EXTERNAL_DEVICETREE_EMMC:stm32mp25-disco = "stm32mp257f-dk-ca35tdcid-ostl"
+EXTERNAL_DEVICETREE_EMMC:stm32mp25-disco =+ "stm32mp257f-dk-ca35tdcid-ostl-m33-examples"

--- a/recipes-images/images/torizon-core-docker.bbappend
+++ b/recipes-images/images/torizon-core-docker.bbappend
@@ -9,3 +9,13 @@ UBOOT_BINARY_TEZI_EMMC:stm32mp25-eval = "fip/fip-stm32mp257f-ev1-optee-emmc.bin"
 OFFSET_BOOTROM_PAYLOAD:stm32mp25-eval = "0"
 TORADEX_PRODUCT_IDS:stm32mp25-eval = "0100"
 UBOOT_ENV_TEZI_EMMC:stm32mp25-eval = ""
+
+# NOTE: ignore OTA bootloader until the recipe is implemented
+UBOOT_BINARY_OTA_IGNORE:stm32mp25-disco = "1"
+
+IMAGE_FSTYPES:append:stm32mp25-disco = " teziimg"
+TEZI_USE_BOOTFILES:stm32mp25-disco = "false"
+UBOOT_BINARY_TEZI_EMMC:stm32mp25-disco = "fip/fip-stm32mp257f-dk-optee-emmc.bin"
+OFFSET_BOOTROM_PAYLOAD:stm32mp25-disco = "0"
+TORADEX_PRODUCT_IDS:stm32mp25-disco = "0100"
+UBOOT_ENV_TEZI_EMMC:stm32mp25-disco = ""

--- a/recipes-kernel/linux/device-tree-overlays_%.bbappend
+++ b/recipes-kernel/linux/device-tree-overlays_%.bbappend
@@ -2,3 +2,8 @@ KERNEL_INCLUDE:stm32mp25-eval = " \
 "
 
 COMPATIBLE_MACHINE:stm32mp25-eval = "stm32mp25-eval"
+
+KERNEL_INCLUDE:stm32mp25-disco = " \
+"
+
+COMPATIBLE_MACHINE:stm32mp25-disco = "stm32mp25-disco"


### PR DESCRIPTION
Unit test:

Build TorizonOS for the stm32mp25-disco board:

$$ MACHINE=stm32mp25-disco DISTRO=torizon source setup-environment build-stm32mp25-disco
$$ bitbake torizon-core-docker

Run the TorizonOS on the ST32MP2 Discovery Kit