### PR TITLE
STMP32MP2-18 support for the MP1 discovery kit

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -31,26 +31,34 @@ LAYERSERIES_COMPAT_toradex-st-layer = "kirkstone"
 # Torizon 6.x is based on kirkstone, add compatibility for STM32MP2 layer
 LAYERSERIES_COMPAT_stm-st-stm32mp:append = " kirkstone"
 
-# NOTE: don't apply I.MX firmware for STM32MP2 targets
+# NOTE: don't apply I.MX firmware for STM32MP1/2 targets
 BBMASK:stm32mp2common += "meta-toradex-bsp-common/recipes-kernel/linux-firmware/linux-firmware_%.bbappend"
+BBMASK:stm32mp1common += "meta-toradex-bsp-common/recipes-kernel/linux-firmware/linux-firmware_%.bbappend"
 
 # NOTE: disable ST images not required for TorizonOS distro
 ST_BOOTFS:stm32mp2common   ?= "0"
 ST_VENDORFS:stm32mp2common ?= "0"
 ST_USERFS:stm32mp2common   ?= "0"
+ST_BOOTFS:stm32mp1common   ?= "0"
+ST_VENDORFS:stm32mp1common ?= "0"
+ST_USERFS:stm32mp1common   ?= "0"
 
 # NOTE: remove dependency on userfs since we don't build it
 WKS_FILE_DEPENDS:remove:stm32mp2common = "st-image-userfs"
+WKS_FILE_DEPENDS:remove:stm32mp1common = "st-image-userfs"
 
 # Apply TorizonOS boot script and U-Boot env structure with specifics to STM32MP2 U-Boot
 BBMASK:stm32mp2common += "meta-toradex-torizon/recipes-bsp/u-boot/u-boot-distro-boot.bbappend"
+BBMASK:stm32mp1common += "meta-toradex-torizon/recipes-bsp/u-boot/u-boot-distro-boot.bbappend"
 PREFERRED_PROVIDER_u-boot-default-script = "u-boot-distro-boot"
 
 # STM32MP2 bootarg to enable UART console
 OSTREE_KERNEL_ARGS:stm32mp2common = "earlyprintk earlycon console=ttySTM0,115200"
+OSTREE_KERNEL_ARGS:stm32mp1common = "earlyprintk earlycon console=ttySTM0,115200"
 
 # Build ext4 image for the OSTree based OTA image
 TEZI_ROOT_SUFFIX:stm32mp2common = "ota-ext4"
+TEZI_ROOT_SUFFIX:stm32mp1common = "ota-ext4"
 
 # Use ota-ext4 image instead of default ext4 for rootfs and mark the rootfs partiotion as System.
 # Note that rootfs is the only filesystem image to be installed since bootfs, vendorfs and

--- a/recipes-bsp/u-boot/u-boot-distro-boot.bbappend
+++ b/recipes-bsp/u-boot/u-boot-distro-boot.bbappend
@@ -10,6 +10,8 @@ SRC_URI:append = " \
 # representing device-tree overlays) to be used when booting.
 FITCONF_FDT_OVERLAYS ??= ""
 
+KERNEL_BOOTCMD:arm ??= "bootm"
+
 do_compile:append () {
     bbdebug 1 "Building uEnv.txt..."
     sed -e 's/@@KERNEL_BOOTCMD@@/${KERNEL_BOOTCMD}/' \

--- a/recipes-bsp/u-boot/u-boot-distro-boot/boot.cmd.in
+++ b/recipes-bsp/u-boot/u-boot-distro-boot/boot.cmd.in
@@ -24,9 +24,9 @@ env set fdtfile2 "${fdtfile}"
 
 if test -n "${loadaddr}"
 then
-    ext4load ${devtype} ${devnum}:6 ${loadaddr} /boot/loader/uEnv.txt; env import -t ${loadaddr} ${filesize}
+    ext4load ${devtype} ${devnum}:${distro_bootpart} ${loadaddr} /boot/loader/uEnv.txt; env import -t ${loadaddr} ${filesize}
 else
-    ext4load ${devtype} ${devnum}:6 ${scriptaddr} /boot/loader/uEnv.txt; env import -t ${scriptaddr} ${filesize}
+    ext4load ${devtype} ${devnum}:${distro_bootpart} ${scriptaddr} /boot/loader/uEnv.txt; env import -t ${scriptaddr} ${filesize}
 fi
 
 run bootcmd_run

--- a/recipes-bsp/u-boot/u-boot-distro-boot/uEnv.txt.in
+++ b/recipes-bsp/u-boot/u-boot-distro-boot/uEnv.txt.in
@@ -1,6 +1,6 @@
 kernel_image_type=@@KERNEL_IMAGETYPE@@
 overlays_file="overlays.txt"
-otaroot=6
+#otaroot=6
 fitconf_fdt_overlays="@@FITCONF_FDT_OVERLAYS@@"
 
 set_root_part=if test ${boot_instance} = "0"; then \
@@ -34,7 +34,7 @@ set_bootargs=env set bootcmd_args env set bootargs ${defargs} root=PARTUUID=${ro
 # used actually, so cancel the unzip command
 set_kernel_load_addr=env set bootcmd_unzip_k ';'; env set kernel_addr_load ${kernel_addr_r}
 
-load_overlay=load ${devtype} ${devnum}:${otaroot} ${loadaddr} /boot${fdtdir}/${overlays_file}; env import -t ${loadaddr} ${filesize}
+load_overlay=load ${devtype} ${devnum}:${distro_bootpart} ${loadaddr} /boot${fdtdir}/${overlays_file}; env import -t ${loadaddr} ${filesize}
 apply_overlays=if test ${kernel_image_type} = "fitImage"; then \
                    env set fdt_high; \
                    env set fdt_resize true; \
@@ -47,14 +47,14 @@ apply_overlays=if test ${kernel_image_type} = "fitImage"; then \
                    fdt mknode /chosen overlays && \
                    for overlay_file in ${fdt_overlays}; do \
                        echo "Applying Overlay: ${overlay_file}" && \
-                       load ${devtype} ${devnum}:${otaroot} ${loadaddr} /boot${fdtdir}/overlays/${overlay_file} && fdt apply ${loadaddr}; \
+                       load ${devtype} ${devnum}:${distro_bootpart} ${loadaddr} /boot${fdtdir}/overlays/${overlay_file} && fdt apply ${loadaddr}; \
                        fdt set /chosen/overlays ${overlay_file} $?; \
                    done; \
                fi
 
-bootcmd_load_k=load ${devtype} ${devnum}:${otaroot} ${kernel_addr_load} "/boot"${kernel_image}
+bootcmd_load_k=load ${devtype} ${devnum}:${distro_bootpart} ${kernel_addr_load} "/boot"${kernel_image}
 bootcmd_load_r=if test ${kernel_image_type} != "fitImage"; then \
-                   load ${devtype} ${devnum}:${otaroot} ${ramdisk_addr_r} "/boot"${ramdisk_image}; env set ramdisk_size ${filesize}; \
+                   load ${devtype} ${devnum}:${distro_bootpart} ${ramdisk_addr_r} "/boot"${ramdisk_image}; env set ramdisk_size ${filesize}; \
                fi || true
 
 # check kernel_image2 to avoid booting from other then default emmc in case of
@@ -76,10 +76,10 @@ set_fdt_path=if test -n "${fdtdir}"; then \
              fi || true
 
 bootcmd_dtb=if test ${kernel_image_type} != "fitImage"; then \
-                load ${devtype} ${devnum}:${otaroot} ${fdt_addr_r} ${fdt_path}; \
+                load ${devtype} ${devnum}:${distro_bootpart} ${fdt_addr_r} ${fdt_path}; \
             fi || true; \
             if test ${skip_fdt_overlays} != 1; then \
-                    if test -e ${devtype} ${devnum}:${otaroot} /boot${fdtdir}/${overlays_file}; then \
+                    if test -e ${devtype} ${devnum}:${distro_bootpart} /boot${fdtdir}/${overlays_file}; then \
                         run load_overlay && run apply_overlays || true; \
                     fi || true; \
             fi || true

--- a/recipes-images/images/torizon-core-docker.bbappend
+++ b/recipes-images/images/torizon-core-docker.bbappend
@@ -19,3 +19,13 @@ UBOOT_BINARY_TEZI_EMMC:stm32mp25-disco = "fip/fip-stm32mp257f-dk-optee-emmc.bin"
 OFFSET_BOOTROM_PAYLOAD:stm32mp25-disco = "0"
 TORADEX_PRODUCT_IDS:stm32mp25-disco = "0100"
 UBOOT_ENV_TEZI_EMMC:stm32mp25-disco = ""
+
+# NOTE: ignore OTA bootloader until the recipe is implemented
+UBOOT_BINARY_OTA_IGNORE:stm32mp15-disco = "1"
+
+IMAGE_FSTYPES:append:stm32mp15-disco = " teziimg"
+TEZI_USE_BOOTFILES:stm32mp15-disco = "false"
+UBOOT_BINARY_TEZI_EMMC:stm32mp15-disco = "fip/fip-stm32mp157f-dk2-optee-sdcard.bin"
+OFFSET_BOOTROM_PAYLOAD:stm32mp15-disco = "0"
+TORADEX_PRODUCT_IDS:stm32mp15-disco = "0100"
+UBOOT_ENV_TEZI_EMMC:stm32mp15-disco = ""

--- a/recipes-kernel/linux/device-tree-overlays_%.bbappend
+++ b/recipes-kernel/linux/device-tree-overlays_%.bbappend
@@ -7,3 +7,8 @@ KERNEL_INCLUDE:stm32mp25-disco = " \
 "
 
 COMPATIBLE_MACHINE:stm32mp25-disco = "stm32mp25-disco"
+
+
+KERNEL_INCLUDE:stm32mp15-disco = " \
+"
+COMPATIBLE_MACHINE:stm32mp15-disco = "stm32mp15-disco"

--- a/scripts/setup-environment
+++ b/scripts/setup-environment
@@ -115,7 +115,7 @@ fi
 # Create a common list of "<machine>(<layer>)", sorted by <machine>
 # Blacklist unsupported machines of TorizonCore
 MACHLAYERS=$(find layers/ -print | grep "conf/machine/.*\.conf" |
-            grep -E '(apalis.*\.conf|colibri.*\.conf|verdin.*\.conf|qemuarm64\.conf|genericx86-64\.conf|stm32mp2.*\.conf)' |
+            grep -E '(apalis.*\.conf|colibri.*\.conf|verdin.*\.conf|qemuarm64\.conf|genericx86-64\.conf|stm32mp2.*\.conf|stm32mp1.*\.conf)' |
             grep -E -v '(imx7-nand|colibri-vf|tk1|colibri-imx7|colibri-imx6ull|verdin-am62-k3r5)\.conf' |
             sed -e 's/\.conf//g' -e 's/layers\///' |
             awk -F'/conf/machine/' '{print $NF "(" $1 ")"}' | LC_ALL=C sort)


### PR DESCRIPTION
Added support for installing  TorizonOS to and booting from SD card, added support for STM32MP1 discovery kits

Unit test:

 * install TorizonOS to SD card on the STMP32MP2-EVAL and STMP32MP2-DISCO target boards, verify that they are functional including update from the Cloud
 * build TorizoOS for the STM32MP1 discovery kit: MACHINE=stm32mp15-disco DISTRO=torizon source setup-environment build-stm32mp15-disco
 * successfully install the built artifacts to the SD card to the STM32MP157C-DK2 board
 * verify that OS is bootable up to the login prompt on the serial console
