### PR TITLE
STM32MP2-23: Support stm32mp15-disco, stm32mp25-disco MACHINEs.

### DIFF
--- a/recipes-images/images/torizon-docker.bbappend
+++ b/recipes-images/images/torizon-docker.bbappend
@@ -26,7 +26,7 @@ UBOOT_BINARY_OTA_IGNORE:stm32mp15-disco = "1"
 
 IMAGE_FSTYPES:append:stm32mp15-disco = " teziimg"
 TEZI_USE_BOOTFILES:stm32mp15-disco = "false"
-UBOOT_BINARY_TEZI_EMMC:stm32mp15-disco = "fip/fip-stm32mp157f-dk2-optee-sdcard.bin"
+UBOOT_BINARY_TEZI_EMMC:stm32mp15-disco = "fip/fip-stm32mp157f-dk2-opteemin-sdcard.bin"
 OFFSET_BOOTROM_PAYLOAD:stm32mp15-disco = "0"
 TORADEX_PRODUCT_IDS:stm32mp15-disco = "0100"
 UBOOT_ENV_TEZI_EMMC:stm32mp15-disco = ""

--- a/scripts/setup-environment
+++ b/scripts/setup-environment
@@ -159,7 +159,7 @@ else
         smarc-rzv2l)
             DISTRO="common-torizon" . ${_TDX_SCRIPTS_PATH}/setup-environment-renesas
         ;;
-        stm32mp25-eval)
+        stm32mp25-eval|stm32mp15-disco|stm32mp25-disco)
 #            DISTRO="common-torizon" . "${_TDX_LAYERS_DIR}"/meta-emcraft-torizon-st/scripts/setup-environment-stm32mp
             DISTRO="torizon" . layers/meta-emcraft-torizon-st/scripts/setup-environment-stm32mp
 #            . ${_TDX_SCRIPTS_PATH}/setup-environment-toradex $@


### PR DESCRIPTION
Fixes for stm32mp15-disco, sm32mp25-disco. Tested for the clean build of "bitbake torizon-docker".